### PR TITLE
Prettify code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R:
            email = "nsrocker92@gmail.com")
 Description: 
     Unravel is an R package and Addin designed to help data scientists understand and explore tidyverse R code 
-    which makes use of the fluent interface (function composition). Unravel is designed to run inside 
+    which makes use of the fluent interface to compose functions using pipes. Unravel is designed to run inside 
     RStudio as a Shiny app accessed through Addins or programmatically.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/R/code_analysis.R
+++ b/R/code_analysis.R
@@ -224,7 +224,7 @@ get_output_intermediates <- function(pipeline) {
     # we collapse it before further processing to avoid extra \t
     deparsed <- paste0(rlang::expr_deparse(verb), collapse = "")
     # append a \t and a pipe character %>% or ggplot + unless it's the last line
-    deparsed <- ifelse(i != 1, paste0("\t", deparsed), deparsed)
+    deparsed <- ifelse(i != 1, style_long_line(verb), deparsed)
     # setup the intermediate list with initial information
     intermediate <- list(line = i, code = deparsed, change = get_change_type(verb_name))
     err <- NULL

--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -69,8 +69,8 @@ group_item_div <- function(line, ns_id) {
   square_css <- ifelse(nzchar(col), "square", "rect")
   core_divs <- list(
     # row div
-    shiny::div(class = "justify-content-center align-self-baseline",
-        shiny::div(class = "d-flex justify-content-center align-self-center",
+    shiny::div(class = "justify-content-center align-self-center",
+        shiny::div(class = "d-flex justify-content-center align-self-baseline",
             shiny::div(class = "row", style = "font-size:0.8em;",
                 shiny::HTML("&nbsp;")
             )
@@ -83,7 +83,7 @@ group_item_div <- function(line, ns_id) {
         )
     ),
     # column div + square div
-    shiny::div(class = "justify-content-center align-self-baseline",
+    shiny::div(class = "justify-content-center align-self-center",
         shiny::div(class = glue::glue("{id}-summary-box-col d-flex justify-content-center align-self-center"),
             shiny::div(class = glue::glue("{id}-col-content row"), style = "font-size:0.8em;",
                 # update element
@@ -248,8 +248,9 @@ unravelServer <- function(id, user_code = NULL) {
           tryCatch({
             # it could be possible that we receive multiple expressions
             # in this case, we only take the first one for now
-            quoted <- rlang::parse_exprs(input$code_ready)
-            outputs <- get_output_intermediates(quoted[[1]])
+            message(input$code_ready)
+            quoted <- rlang::parse_expr(input$code_ready)
+            outputs <- get_output_intermediates(quoted)
             # set reactive values
             rv$code_info <- lapply(outputs, function(x) {
               list(

--- a/R/unravel_helper.R
+++ b/R/unravel_helper.R
@@ -28,10 +28,10 @@ generate_code_info_outputs <- function(order, rv) {
     classes <- new_code_info[[i]]$class
     code <- new_code_info[[i]]$code
     classes <- new_code_info[[i]]$class
-    # split the string then only keep the strings besides the last one (%>% or +)
-    split_code <- unlist(strsplit(code, " "))
-    trim <- ifelse(length(split_code) > 1, 1, 0)
-    new_code_info[[i]]$code <- paste0(split_code[1:length(split_code) - trim], collapse=" ")
+    # replace any %>% and + at the end of the line
+    code <- gsub("%>%\\s*$", "", code)
+    code <- gsub("\\+\\s*$", "", code)
+    new_code_info[[i]]$code <- code
     new_code_info[[i]]
   })
   # then, apply it on every line except the last

--- a/inst/css/codemirror.css
+++ b/inst/css/codemirror.css
@@ -19,7 +19,7 @@
 }
 
 .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
-  background-color: transparent; /* The little square between H and V scrollbars */
+  background-color: white; /* The little square between H and V scrollbars */
 }
 
 /* GUTTER */
@@ -60,20 +60,13 @@
 .cm-fat-cursor div.CodeMirror-cursors {
   z-index: 1;
 }
-.cm-fat-cursor-mark {
-  background-color: rgba(20, 255, 20, 0.5);
-  -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  animation: blink 1.06s steps(1) infinite;
-}
-.cm-animate-fat-cursor {
-  width: auto;
-  border: 0;
-  -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  animation: blink 1.06s steps(1) infinite;
-  background-color: #7e7;
-}
+.cm-fat-cursor .CodeMirror-line::selection,
+.cm-fat-cursor .CodeMirror-line > span::selection, 
+.cm-fat-cursor .CodeMirror-line > span > span::selection { background: transparent; }
+.cm-fat-cursor .CodeMirror-line::-moz-selection,
+.cm-fat-cursor .CodeMirror-line > span::-moz-selection,
+.cm-fat-cursor .CodeMirror-line > span > span::-moz-selection { background: transparent; }
+.cm-fat-cursor { caret-color: transparent; }
 @-moz-keyframes blink {
   0% {}
   50% { background-color: transparent; }

--- a/inst/css/style.css
+++ b/inst/css/style.css
@@ -223,11 +223,8 @@ h2 {
 .list-group-item {
   width: 100%;
   height: auto;
-  /*border: 1px solid #eee;*/
-  padding: 0px;
-  margin: 0px;
+  padding: 0.25em;
   display: flex;
-  /* align-items: center; */
 }
 
 .list-group-item:hover {

--- a/inst/js/explorer.js
+++ b/inst/js/explorer.js
@@ -34,9 +34,9 @@ function setup_editors() {
         readOnly: 'nocursor',
         styleActiveLine: false,
         lineNumbers: false,
-        firstLineNumber: 1
+        firstLineNumber: 1,
+        viewportMargin: Infinity
       });
-      line_editor.setSize(null, 50);
       let line_class = '.' + ID;
       let line_id = index + 1;
       let line_glyph = $(line_class + '-glyph')[0];

--- a/tests/testthat/test-styler.R
+++ b/tests/testthat/test-styler.R
@@ -1,0 +1,39 @@
+
+test_that("Styling tidyverse code works", {
+  symbol_args <- quote(
+    starwars %>%
+      select(name, height, mass, hair_color, skin_color, eye_color, birth_year,
+             sex, gender, homeworld, species, films, vehicles
+    )
+  )
+  expect_equal(
+    style_dplyr_code(symbol_args),
+    "starwars %>%\n\tselect(\n\t\tname, height, mass, hair_color, skin_color, eye_color, birth_year,\n\t\tsex, gender, homeworld, species, films, vehicles\n\t)"
+  )
+
+  expr_args <- quote(
+    starwars %>%
+      drop_na(birth_year) %>%
+      group_by(species) %>%
+      summarise(
+        across(c(sex, gender, homeworld), ~ length(unique(.x))),
+        across(birth_year, ~ mean(.x, na.rm = TRUE)), across(birth_year, ~ mean(.x, na.rm = TRUE))
+      )
+  )
+  expect_equal(
+    style_dplyr_code(expr_args),
+    "starwars %>%\n\tdrop_na(birth_year) %>%\n\tgroup_by(species) %>%\n\tsummarise(\n\t\tacross(c(sex, gender, homeworld), ~length(unique(.x))),\n\t\tacross(birth_year, ~mean(.x, na.rm = TRUE)), across(birth_year, ~mean(.x, na.rm = TRUE))\n\t)"
+  )
+
+  mixed_expr_args <- quote(
+    starwars %>%
+      drop_na(birth_year) %>%
+      group_by(species) %>%
+      summarise(across(c(sex, gender, homeworld), ~ length(unique(.x))), birth_year_avg = mean(birth_year, na.rm = TRUE))
+  )
+  expect_equal(
+    style_dplyr_code(mixed_expr_args),
+    "starwars %>%\n\tdrop_na(birth_year) %>%\n\tgroup_by(species) %>%\n\tsummarise(\n\t\tacross(c(sex, gender, homeworld), ~length(unique(.x))),\n\t\tbirth_year_avg = mean(birth_year, na.rm = TRUE)\n\t)"
+  )
+
+})

--- a/tests/testthat/test-styler.R
+++ b/tests/testthat/test-styler.R
@@ -8,7 +8,7 @@ test_that("Styling tidyverse code works", {
   )
   expect_equal(
     style_dplyr_code(symbol_args),
-    "starwars %>%\n\tselect(\n\t\tname, height, mass, hair_color, skin_color, eye_color, birth_year,\n\t\tsex, gender, homeworld, species, films, vehicles\n\t)"
+    "starwars %>%\n\tselect(\n\t\tname, height, mass, hair_color, skin_color, eye_color,\n\t\tbirth_year, sex, gender, homeworld, species, films, vehicles\n\t)"
   )
 
   expr_args <- quote(
@@ -17,12 +17,13 @@ test_that("Styling tidyverse code works", {
       group_by(species) %>%
       summarise(
         across(c(sex, gender, homeworld), ~ length(unique(.x))),
-        across(birth_year, ~ mean(.x, na.rm = TRUE)), across(birth_year, ~ mean(.x, na.rm = TRUE))
+        across(birth_year, ~ mean(.x, na.rm = TRUE)),
+        across(birth_year, ~ mean(.x, na.rm = TRUE))
       )
   )
   expect_equal(
     style_dplyr_code(expr_args),
-    "starwars %>%\n\tdrop_na(birth_year) %>%\n\tgroup_by(species) %>%\n\tsummarise(\n\t\tacross(c(sex, gender, homeworld), ~length(unique(.x))),\n\t\tacross(birth_year, ~mean(.x, na.rm = TRUE)), across(birth_year, ~mean(.x, na.rm = TRUE))\n\t)"
+    "starwars %>%\n\tdrop_na(birth_year) %>%\n\tgroup_by(species) %>%\n\tsummarise(\n\t\tacross(c(sex, gender, homeworld), ~length(unique(.x))),\n\t\tacross(birth_year, ~mean(.x, na.rm = TRUE)),\n\t\tacross(birth_year, ~mean(.x, na.rm = TRUE))\n\t)"
   )
 
   mixed_expr_args <- quote(


### PR DESCRIPTION
# Description

This PR addresses issue #95 by adding utility functions to re-style the code, and changes the code overlay to support multi-line output.

Unraveling code with especially long lines currently forces horizontal scrolling which harms UX/readability:

<img width="525" alt="Screen Shot 2021-12-19 at 2 29 38 PM" src="https://user-images.githubusercontent.com/9612286/146688192-bd71aa86-4bc1-4c9e-ade6-61b0308ffb06.png">

when we could produce a re-formatted line like so:

<img width="544" alt="Screen Shot 2021-12-19 at 2 31 35 PM" src="https://user-images.githubusercontent.com/9612286/146688246-1470c52d-adb0-4dec-a3b7-89c46a024efc.png">

TODOs:
- [x] core utility functions
- [x] add tests
- [x] front-end changes to Codemirror logic