### PR TITLE
Add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # User-specific files
 .Ruserdata
+.Rprofile
 
 # Example code in package build process
 *-Ex.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,21 +15,23 @@ Description:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-Depends:
-    tidyverse,
+Imports:
+    tibble,
     dplyr,
+    tidyr,
+    purrr,
+    ggplot2,
     reactable,
     tidylog,
-    shiny
-Imports:
+    shiny,
     magrittr,
     here,
-    babynames,
-    gapminder,
     rstudioapi,
     rlang,
     glue,
-    crayon
+    crayon,
+    babynames,
+    gapminder
 Remotes:
     nischalshrestha/tidylog
 RoxygenNote: 7.1.1

--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -256,10 +256,12 @@ unravelServer <- function(id, user_code = NULL) {
       # listen for JS to tell us code is ready for us to be processed
       observeEvent(input$code_ready, {
         # message("Receiving code from JS: ", input$code_ready)
+
         # TODO-refactor: process lines function?
         # process lines
         if (!is.null(input$code_ready) && nzchar(input$code_ready)) {
           err <- NULL
+          log_info(paste0(c("unraveling code", input$code_ready), collapse = "|"))
           tryCatch(
             {
               # it could be possible that we receive multiple expressions
@@ -381,6 +383,7 @@ unravelServer <- function(id, user_code = NULL) {
         # message("clicked on a square: ", input$square)
         # make sure to only change current if the current code info has the line marked as enabled
         if (!is.null(input$square)) {
+          log_event(paste0("viewed summary for line ", input$square))
           rv$current <- input$square
           session$sendCustomMessage("square", input$square)
         }
@@ -390,6 +393,7 @@ unravelServer <- function(id, user_code = NULL) {
         # message("clicked on a line: ", input$line)
         # make sure to only change current if the current code info has the line marked as enabled
         if (!is.null(input$line)) {
+          log_event(paste0("clicked line ", input$line))
           rv$current <- input$line
           session$sendCustomMessage("line", input$line)
         }
@@ -493,8 +497,10 @@ unravelServer <- function(id, user_code = NULL) {
         # this lets us get the boolean value of the toggle from JS side!
         if (isTRUE(input$toggle$checked)) {
           session$sendCustomMessage("toggle", paste0("un-commenting line ", input$toggle$lineid))
+          log_event(paste0("toggled on line ", input$toggle$lineid))
         } else {
           session$sendCustomMessage("toggle", paste0("commenting line ", input$toggle$lineid))
+          log_event(paste0("toggled off line ", input$toggle$lineid))
         }
         line_id <- as.numeric(input$toggle$lineid)
         checked <- input$toggle$checked
@@ -528,6 +534,8 @@ unravelServer <- function(id, user_code = NULL) {
         # message("REORDER", input$reorder)
         # this lets us get the boolean value of the toggle from JS side!
         order <- as.numeric(input$reorder)
+
+        log_event(paste0("reordered lines to ", paste0(order, collapse=", ")))
 
         # set and get the new order from current code stat
         attr(rv$current_code_info, "order") <- order

--- a/R/utils.R
+++ b/R/utils.R
@@ -115,3 +115,27 @@ reappend <- function(...) {
 match_gregexpr <- function(pattern, string, which_one = 1) {
   gregexpr(pattern, string)[[1]][[which_one]]
 }
+
+log_info <- function(event) {
+  log_unravel("INFO", event)
+}
+
+log_event <- function(event) {
+  log_unravel("EVENT", event)
+}
+
+log_unravel <- function(type, message) {
+  # if logging is enabled, log
+  if (getOption("unravel.logging")) {
+    # grab the dir and file name from options so it can be customized
+    dir_name <- getOption("unravel.logdir")
+    logfile_name <- getOption("unravel.logfile")
+    dir.create(dir_name, showWarnings = FALSE)
+    timestamp <- format(Sys.time())
+    cat(
+      paste0(c(type, timestamp, message), collapse = "|"), "\n",
+      file = file.path(dir_name, logfile_name), sep = "", append = TRUE
+    )
+  }
+  invisible()
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,6 @@
+
 .onLoad <- function(libname, pkgname) {
-  # set tidylog messages to re-route to our tidylog_cache environment so we can access it
+  # the tidylog messages re-routes to our `tidylog_cache` environment (see utils.R) so we can access it
   # this is done after all the utility functions for getting/setting summaries are defined above
   options(
     "tidylog.display" = list(store_verb_summary),

--- a/tests/testthat/test-code_analysis.R
+++ b/tests/testthat/test-code_analysis.R
@@ -1,3 +1,8 @@
+library(dplyr)
+library(tidyr)
+library(purrr)
+library(ggplot2)
+library(tidylog)
 
 test_that("One liner functions", {
   # only dataframe


### PR DESCRIPTION
# Description

This PR address issue #67 by adding logging capability within Unravel for understanding its use or debugging purposes. It's a very basic logging system where we are writing to an `outputs/events.log` file that are based on type of log like `INFO`, `EVENT` for now. The following `options()` are used and can be easily set using a `.Rprofile` or manually:

```r
options(
  "unravel.logdir" = "outputs", # the directory name to store log file
  "unravel.logfile" = "events.log", # the name of the logfile
  "unravel.logging" = FALSE # whether the logging should be turned on/off
)
```

## Minor changes

Along with that we converted depends to import to reduce directly loading too many packages, and do not depend on the entire tidyverse. The tests adds library imports for this reason.