### PR TITLE
Reduce noise in logging click events

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -134,10 +134,10 @@ log_unravel <- function(type, message, path = "", context = "unravel", storage =
     store_log(
       list(
         timestamp = timestamp,
-        context = context,
-        path = path,
         type = type,
-        message = message
+        message = message,
+        path = path,
+        context = context
       ),
       storage = storage
     )
@@ -145,7 +145,7 @@ log_unravel <- function(type, message, path = "", context = "unravel", storage =
 }
 
 store_log <- function(..., storage = "sqlite",
-                      db_cols = c("timestamp", "context", "path", "type", "message")) {
+                      db_cols = c("timestamp", "type", "message", "path", "context")) {
   variables <- force(...)
   if (length(variables) == 0) {
     stop("Log contained no values!")

--- a/inst/js/explorer.js
+++ b/inst/js/explorer.js
@@ -12,6 +12,7 @@ var last_line_wrapper = null;
 // the last line's callout nodes
 var last_callout_nodes = null;
 var has_error = false;
+var auto_focus = false;
 
 /*
 EDITOR
@@ -170,6 +171,7 @@ function setup_prompts(summaries) {
       line.prompt = line_tippy;
     }
   }
+  auto_focus = true;
   last_line_wrapper.click();
   console.log("JS has set prompts! " + last_line_wrapper);
 }
@@ -246,7 +248,6 @@ function signal_square_clicked(e) {
     last_line_wrapper = line.wrapper;
     last_callout_nodes = line.callout_nodes;
   }
-
   Shiny.setInputValue("unravel-square", key, {priority: "event"});
 }
 
@@ -269,7 +270,11 @@ function signal_line_clicked(e) {
     // the last line wrapper and callout nodes will be set here when setting up listeners
     last_line_wrapper = line.wrapper;
     last_callout_nodes = line.callout_nodes;
-    Shiny.setInputValue("unravel-line", square, {priority: "event"});
+    if (!auto_focus) {
+      Shiny.setInputValue("unravel-line", square, {priority: "event"});
+    } else {
+      auto_focus = false;
+    }
   }
 }
 
@@ -370,7 +375,7 @@ $(document).on("shiny:sessioninitialized", function(event) {
 
   /*
   * Table interaction logging:
-  * The following 3 event listeners are for logging if users hover, or clicks
+  * The following 2 event listeners are for logging if users hover, or click
   * on `reactable`
   */
 


### PR DESCRIPTION
This small PR reduces noise in the logging of click events by not logging cases where we automatically focus on a line for the sake of UX. We do this when unraveling code, whether it's the initial unravel or the structured edit updates by focusing in on the last line of the valid expression. However, this is not user initiated so we make sure to only log if the user performed the click/hover.

We also fixed another inconsistent argument ordering for the `store_log` function invocation and definition.
