### PR TITLE
Enable invoking function help

### DIFF
--- a/R/code_analysis.R
+++ b/R/code_analysis.R
@@ -112,7 +112,9 @@ gather_callouts <- function(callouts, deparsed) {
     filtered_tree <- filtered_tree[filtered_tree$token == "SYMBOL_SUB", ]
   }
   # grab the col1, col2 and store them as 2 more items in the callouts list
-  filtered_callouts <- filtered_tree[filtered_tree$text %in% callout_words, c('text', 'line1', 'line2', 'col1', 'col2')]
+  filtered_callouts <- filtered_tree[
+    filtered_tree$text %in% callout_words, c('text', 'line1', 'line2', 'col1', 'col2')
+  ]
   if (nrow(filtered_callouts) > 0) {
     # return a list of callouts with the range information baked in for JS to mark
     return(
@@ -140,11 +142,14 @@ gather_fns_help <- function(fns_help, deparsed) {
   # store some info about the range so JS knows which
   code <- substring(deparsed, 2, nchar(deparsed))
   parse_tree <- getParseData(parse(text = code))
+  fns_help_words <- lapply(fns_help, function(x) x$word)
   # grab the col1, col2, and text
-  filtered_fns_help <- parse_tree[
-    parse_tree$token == 'SYMBOL_FUNCTION_CALL', c('text', 'line1', 'line2', 'col1', 'col2')
+  filtered_tree <- parse_tree[parse_tree$token == 'SYMBOL_FUNCTION_CALL', ]
+  filtered_fns_help <- filtered_tree[
+    filtered_tree$text %in% fns_help_words, c('text', 'line1', 'line2', 'col1', 'col2')
   ]
   if (nrow(filtered_fns_help) > 0) {
+    # return a list of callouts with the range information baked in for JS to mark
     return(
       list(
         modifyList(

--- a/R/code_analysis.R
+++ b/R/code_analysis.R
@@ -97,34 +97,71 @@ get_data_change_type <- function(verb_name, prev_output, cur_output) {
 
 # helper function to add some range info for the callout words
 gather_callouts <- function(callouts, deparsed) {
+  if (is.null(callouts)) return(NULL)
   # store some info about the range so JS knows which
   code <- substring(deparsed, 2, nchar(deparsed))
   parse_tree <- getParseData(parse(text = code))
   callout_words <- lapply(callouts, function(x) x$word)
-  # FIXME in some expressions, we only want certain callouts like named argument
-  # e.g `summarise(n = n(), price = mean(price))`, we only want the first `n` because it's a column
-  filtered_calls <- parse_tree[parse_tree$token != 'SYMBOL_FUNCTION_CALL', ]
-  filtered_calls <- filtered_calls[filtered_calls$text %in% unlist(callout_words), ]
+  filtered_tree <- parse_tree[parse_tree$token != 'SYMBOL_FUNCTION_CALL', ]
+  filtered_tree <- filtered_tree[filtered_tree$text %in% unlist(callout_words), ]
+  # if there is an expression for the arguments where we have the same name of the callout word
+  # for both creation of a variable and a symbol within the expression, let's just keep the
+  # tree info for the SYMBOL_SUB
+  has_multiple_instances <- "SYMBOL_SUB" %in% filtered_tree$token && "SYMBOL" %in% filtered_tree$token
+  if (has_multiple_instances) {
+    filtered_tree <- filtered_tree[filtered_tree$token == "SYMBOL_SUB", ]
+  }
   # grab the col1, col2 and store them as 2 more items in the callouts list
-  filtered_callouts <- filtered_calls[callout_words == filtered_calls$text, c('text', 'col1', 'col2')]
+  filtered_callouts <- filtered_tree[filtered_tree$text %in% callout_words, c('text', 'line1', 'line2', 'col1', 'col2')]
   if (nrow(filtered_callouts) > 0) {
+    # return a list of callouts with the range information baked in for JS to mark
     return(
-      modifyList(
-        list(callouts),
-        lapply(
-          callouts,
-          function(callout) {
-            token_info <- filtered_callouts[filtered_callouts$text == callout$word, ]
-            callout['col1'] <- token_info[['col1']]
-            # we increment the end since JS does not include it
-            callout['col2'] <- token_info[['col2']] + 1
-            callout
-          }
+      list(
+        modifyList(
+          lapply(
+            callouts,
+            function(callout) {
+              # store the token range info for each callout word instance
+              token_info <- filtered_callouts[filtered_callouts$text == callout$word, ]
+              callout[['location']] <- list(token_info)
+              callout
+            }
+          ),
+          list(callouts)
         )
       )
     )
   }
   return(list(callouts))
+}
+
+# helper function to add some range info for the function help words
+gather_fns_help <- function(fns_help, deparsed) {
+  # store some info about the range so JS knows which
+  code <- substring(deparsed, 2, nchar(deparsed))
+  parse_tree <- getParseData(parse(text = code))
+  # grab the col1, col2, and text
+  filtered_fns_help <- parse_tree[
+    parse_tree$token == 'SYMBOL_FUNCTION_CALL', c('text', 'line1', 'line2', 'col1', 'col2')
+  ]
+  if (nrow(filtered_fns_help) > 0) {
+    return(
+      list(
+        modifyList(
+          lapply(
+            fns_help,
+            function(fn) {
+              token_info <- filtered_fns_help[filtered_fns_help$text == fn$word, ]
+              fn[['location']] <- list(token_info)
+              fn
+            }
+          ),
+          list(fns_help)
+        )
+      )
+    )
+  }
+  return(list(fns_help))
 }
 
 #' Given an expression of fluent code, return a list of intermediate outputs.
@@ -335,15 +372,14 @@ get_output_intermediates <- function(pipeline) {
         # store the final change type
         intermediate["change"] <- change_type
 
-        # gather the callouts
+        # gather the callouts to mark text in editor
         # store the column strings so we can highlight them as callouts
         callouts <- get_line_callouts()
-        if (!is.null(callouts)) {
-          intermediate["callouts"] <- gather_callouts(callouts, deparsed)
-        }
-
+        intermediate["callouts"] <- gather_callouts(callouts, deparsed)
         # store the help strings so we can make functions links to Help pages
-        intermediate["fns_help"] <- list(get_fns_help())
+        fns_help <- get_fns_help()
+        intermediate["fns_help"] <- gather_fns_help(fns_help, deparsed)
+
         # if we have a dataframe %>% verb() expression, the 'dataframe' summary is simply
         # the dataframe/tibble with dimensions reported (we could expand that if we want)
         if ((i == 1 && (has_pipes || first_arg_data)) || is.null(verb_summary)) {

--- a/R/code_analysis.R
+++ b/R/code_analysis.R
@@ -129,6 +129,7 @@ get_data_change_type <- function(verb_name, prev_output, cur_output) {
 get_output_intermediates <- function(pipeline) {
   clear_verb_summary()
   clear_callouts()
+  clear_fns_help()
   old_verb_summary <- ""
 
   # if code is an assignment expression, grab the value (rhs)
@@ -303,6 +304,8 @@ get_output_intermediates <- function(pipeline) {
         intermediate["change"] <- change_type
         # store the column strings so we can highlight them as callouts
         intermediate["callouts"] <- list(get_line_callouts())
+        # store the help strings so we can make functions links to Help pages
+        intermediate["fns_help"] <- list(get_fns_help())
         # if we have a dataframe %>% verb() expression, the 'dataframe' summary is simply
         # the dataframe/tibble with dimensions reported (we could expand that if we want)
         if ((i == 1 && (has_pipes || first_arg_data)) || is.null(verb_summary)) {

--- a/R/styler.R
+++ b/R/styler.R
@@ -29,7 +29,7 @@ style_dplyr_code <- function(quoted, char_threshold = 50) {
 # return the formmated string
 style_long_line <- function(expr, char_threshold = 50) {
   # determine if the whole line char length exceeds threshold (including the function part e.g. "mutate")
-  exceeds_t <- nchar(paste0(rlang::expr_deparse(expr))) > (char_threshold + 10)
+  exceeds_t <- nchar(paste0(rlang::expr_deparse(expr), collapse = "")) > (char_threshold + 10)
   # if it exceeds length, proceed to style
   if (any(exceeds_t)) {
     # extract function name and the arguments

--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -255,11 +255,12 @@ unravelServer <- function(id, user_code = NULL) {
       rv$outputs <- NULL
       rv$generic_output <- NULL
       rv$table_output <- NULL
-      rv$callouts <- NULL
       # used to trigger output (data.frame/lists)
+      rv$callouts <- NULL
       rv$main_callout <- NULL
       # used to trigger the Help page for a function
       rv$fns_help <- NULL
+      rv$cur_fns_help <- NULL
 
       # send signal to JS of the code text to display
       session$sendCustomMessage("set_code", paste0(user_code))
@@ -316,6 +317,7 @@ unravelServer <- function(id, user_code = NULL) {
               rv$fns_help <- lapply(outputs, function(x) {
                 list(lineid = paste0("line", x$line), fns_help = x$fns_help)
               })
+              rv$cur_fns_help <- lapply(outputs, function(x) x$fns_help)
 
               rv$summaries <- lapply(outputs, function(x) {
                 if (!is.null(x$err)) {
@@ -534,16 +536,16 @@ unravelServer <- function(id, user_code = NULL) {
         fn_ns <- getAnywhere(fn)$where
         # since tidylog gets loaded as part of this package,
         # filter it out so we can get the dplyr/tidyr namespace
-        fn_ns <- Filter(function(ns) !grepl('tidylog', ns), fn_ns)
+        fn_ns <- Filter(function(ns) !grepl('tidylog|Unravel', ns), fn_ns)
         # grab the most relevant namespace that this
         # function belongs to (first element)
         fn_pkg <- unlist(strsplit(fn_ns[[1]], ":"))
-        rv$fns_help <- list(fn = fn, pkg = fn_pkg[[2]])
+        rv$cur_fns_help <- list(fn = fn, pkg = fn_pkg[[2]])
       })
 
       output$fn_help_dummy <- renderPlot({
-        if (!is.null(rv$fns_help) && length(rv$fns_help$pkg) > 0) {
-          help(rv$fns_help$fn, rv$fns_help$pkg)
+        if (!is.null(rv$cur_fns_help) && length(rv$cur_fns_help$pkg) > 0) {
+          help(rv$cur_fns_help$fn, rv$cur_fns_help$pkg)
         }
       })
 

--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -530,10 +530,14 @@ unravelServer <- function(id, user_code = NULL) {
       # invoke the help menu for a particular function
       observeEvent(input$fn_help, {
         fn <- input$fn_help
-        # we're going to grab the most relevant namespace that this
+        # get the namespaces for the function
+        fn_ns <- getAnywhere(fn)$where
+        # since tidylog gets loaded as part of this package,
+        # filter it out so we can get the dplyr/tidyr namespace
+        fn_ns <- Filter(function(ns) !grepl('tidylog', ns), fn_ns)
+        # grab the most relevant namespace that this
         # function belongs to (first element)
-        fn_ns <- getAnywhere(fn)$where[[1]]
-        fn_pkg <- unlist(strsplit(fn_ns, ":"))
+        fn_pkg <- unlist(strsplit(fn_ns[[1]], ":"))
         rv$fns_help <- list(fn = fn, pkg = fn_pkg[[2]])
       })
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,7 +91,6 @@ store_fns_help <- function(fns) {
 get_fns_help <- function() {
   if (exists("fns_help", envir = fns_help_cache)) {
     fns_help <- get("fns_help", envir = fns_help_cache)
-    # message(paste0("getting fns_help ", fns_help))
     return(fns_help)
   }
   return(NULL)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,4 @@
 
-### Verb summary
-
 #' Pipe operator
 #'
 #' See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
@@ -12,6 +10,8 @@
 #' @importFrom magrittr %>%
 #' @usage lhs \%>\% rhs
 NULL
+
+### Function summaries
 
 # empty out the tidylog summary env initially
 tidylog_cache <- new.env(parent=emptyenv())
@@ -65,33 +65,46 @@ clear_callouts <- function() {
   rm(list=ls(callout_cache, all.names=TRUE), envir=callout_cache)
 }
 
-#' Returns an abbreviated version of a number (K for thousndas and M for millions)
-#'
-#' We won't do more than millions of rows for now.
-#'
-#' @param x a numeric
-#' @return a character
-#' @examples
-#' abbrev_num(1950) # 1.95K
-#' abbrev_num(1950000) # 1.95M
-#'
-#' @export
-abbrev_num <- function(x) {
-  if (is.null(x)) {
-    return("")
-  }
-  if (x >= 1e3 && x < 1e6) {
-    return(paste0(format(round(x / 1e3, 1), trim = TRUE), "K"))
-  }
-  else if (x >= 1e6) {
-    return(paste0(format(round(x / 1e6, 1), trim = TRUE), "M"))
-  }
-  return(as.character(x))
+### Linking of Function to Help page
+
+# empty out the tidylog summary env initially
+fns_help_cache <- new.env(parent=emptyenv())
+
+# A helper function to store function words from tidylog
+# and their code text to use when replacing them in
+# the Unravel front-end.
+#
+# For e.g. in `mutate(mtcars, mpg_round = round(mpg))`
+# the `mutate` and `round` are functions for which we
+# have help pages for. So the list could look like:
+#
+# list(
+#   mutate = "<a id = 'mutate' class = 'fn_help'>mutate</a>"),
+#   round = "<a id = 'round' class = 'fn_help'>round</a>"),
+# )
+store_fns_help <- function(fns) {
+  message("storing fns_help")
+  assign("fns_help", fns, envir = fns_help_cache)
 }
 
-match_gregexpr <- function(pattern, string, which_one = 1) {
-  gregexpr(pattern, string)[[1]][[which_one]]
+# helper function to get the current function help words as set by tidylog
+get_fns_help <- function() {
+  if (exists("fns_help", envir = fns_help_cache)) {
+    message("getting fns_help ", fns_help)
+    fns_help <- get("fns_help", envir = fns_help_cache)
+    return(fns_help)
+  }
+  return(NULL)
 }
+
+# helper function to clear the fns_help_cache envir
+clear_fns_help <- function() {
+  message("clearing fns_help")
+  rm(list=ls(fns_help_cache, all.names=TRUE), envir=fns_help_cache)
+}
+
+
+### Logging
 
 log_info <- function(message, context = "unravel") {
   log_unravel("INFO", message, context)
@@ -174,4 +187,34 @@ store_log <- function(..., storage = "sqlite",
     RSQLite::dbDisconnect(mydb)
   }
   invisible()
+}
+
+### Miscellaneous
+
+#' Returns an abbreviated version of a number (K for thousndas and M for millions)
+#'
+#' We won't do more than millions of rows for now.
+#'
+#' @param x a numeric
+#' @return a character
+#' @examples
+#' abbrev_num(1950) # 1.95K
+#' abbrev_num(1950000) # 1.95M
+#'
+#' @export
+abbrev_num <- function(x) {
+  if (is.null(x)) {
+    return("")
+  }
+  if (x >= 1e3 && x < 1e6) {
+    return(paste0(format(round(x / 1e3, 1), trim = TRUE), "K"))
+  }
+  else if (x >= 1e6) {
+    return(paste0(format(round(x / 1e6, 1), trim = TRUE), "M"))
+  }
+  return(as.character(x))
+}
+
+match_gregexpr <- function(pattern, string, which_one = 1) {
+  gregexpr(pattern, string)[[1]][[which_one]]
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -90,8 +90,8 @@ store_fns_help <- function(fns) {
 # helper function to get the current function help words as set by tidylog
 get_fns_help <- function() {
   if (exists("fns_help", envir = fns_help_cache)) {
-    message("getting fns_help ", fns_help)
     fns_help <- get("fns_help", envir = fns_help_cache)
+    message(paste0("getting fns_help ", fns_help))
     return(fns_help)
   }
   return(NULL)
@@ -102,7 +102,6 @@ clear_fns_help <- function() {
   message("clearing fns_help")
   rm(list=ls(fns_help_cache, all.names=TRUE), envir=fns_help_cache)
 }
-
 
 ### Logging
 
@@ -177,14 +176,16 @@ store_log <- function(..., storage = "sqlite",
     )
   } else if (identical(storage, "sqlite")) {
     db_path <- file.path(dir_name, getOption("db.file"))
-    mydb <- RSQLite::dbConnect(RSQLite::SQLite(), db_path)
-    if (length(RSQLite::dbListTables(mydb)) == 0) {
-      RSQLite::dbWriteTable(mydb, "events", tibble::as_tibble(variables))
-    } else {
-      old <- RSQLite::dbReadTable(mydb, "events")
-      RSQLite::dbAppendTable(mydb, "events", tibble::as_tibble(variables))
+    if (file.exists(db_path)) {
+      mydb <- RSQLite::dbConnect(RSQLite::SQLite(), db_path)
+      if (length(RSQLite::dbListTables(mydb)) == 0) {
+        RSQLite::dbWriteTable(mydb, "events", tibble::as_tibble(variables))
+      } else {
+        old <- RSQLite::dbReadTable(mydb, "events")
+        RSQLite::dbAppendTable(mydb, "events", tibble::as_tibble(variables))
+      }
+      RSQLite::dbDisconnect(mydb)
     }
-    RSQLite::dbDisconnect(mydb)
   }
   invisible()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,7 +83,7 @@ fns_help_cache <- new.env(parent=emptyenv())
 #   round = "<a id = 'round' class = 'fn_help'>round</a>"),
 # )
 store_fns_help <- function(fns) {
-  message("storing fns_help")
+  # message("storing fns_help")
   assign("fns_help", fns, envir = fns_help_cache)
 }
 
@@ -91,7 +91,7 @@ store_fns_help <- function(fns) {
 get_fns_help <- function() {
   if (exists("fns_help", envir = fns_help_cache)) {
     fns_help <- get("fns_help", envir = fns_help_cache)
-    message(paste0("getting fns_help ", fns_help))
+    # message(paste0("getting fns_help ", fns_help))
     return(fns_help)
   }
   return(NULL)
@@ -99,7 +99,7 @@ get_fns_help <- function() {
 
 # helper function to clear the fns_help_cache envir
 clear_fns_help <- function() {
-  message("clearing fns_help")
+  # message("clearing fns_help")
   rm(list=ls(fns_help_cache, all.names=TRUE), envir=fns_help_cache)
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,6 +4,7 @@
   # this is done after all the utility functions for getting/setting summaries are defined above
   options(
     "tidylog.display" = list(store_verb_summary),
-    "tidylog.callouts" = store_line_callouts
+    "tidylog.callouts" = store_line_callouts,
+    "tidylog.fns_help" = store_fns_help
   )
 }

--- a/inst/css/style.css
+++ b/inst/css/style.css
@@ -123,7 +123,7 @@ h2 {
 }
 
 .internal-square:hover{
-  cursor:pointer
+  cursor: pointer;
 }
 
 .internal-rect {
@@ -135,7 +135,7 @@ h2 {
 }
 
 .internal-rect:hover{
-  cursor:pointer
+  cursor: pointer;
 }
 
 .none-square {
@@ -146,7 +146,7 @@ h2 {
 }
 
 .none-square:hover{
-  cursor:pointer
+  cursor: pointer;
 }
 
 .none-rect {
@@ -158,7 +158,7 @@ h2 {
 }
 
 .none-rect:hover{
-  cursor:pointer
+  cursor: pointer;
 }
 
 .visible-square {
@@ -169,7 +169,7 @@ h2 {
 }
 
 .visible-square:hover{
-  cursor:pointer
+  cursor: pointer;
 }
 
 .visible-rect {
@@ -181,7 +181,7 @@ h2 {
 }
 
 .visible-rect:hover{
-  cursor:pointer
+  cursor: pointer;
 }
 
 .empty-square {
@@ -359,3 +359,6 @@ input:checked + .slider:before {
   border-radius: 60%;
 }
 
+.fn_help {
+  cursor: help;
+}

--- a/inst/css/style.css
+++ b/inst/css/style.css
@@ -360,5 +360,6 @@ input:checked + .slider:before {
 }
 
 .fn_help {
+  color: #375f84;
   cursor: help;
 }

--- a/inst/js/explorer.js
+++ b/inst/js/explorer.js
@@ -344,6 +344,7 @@ function callout_code_text(callout, verb_doc) {
 
 function setup_callouts(callouts) {
   console.log("got the callouts in JS! " + JSON.stringify(callouts));
+  console.log('length of callouts ' + Object.keys(callouts));
   // for each lineid, add a the callout words field
   // containing a list like: [{word: "foo", change: "internal-change"}, ...]
   callouts.forEach(e => {
@@ -368,6 +369,11 @@ Help text linking
 // TODO implement setup_fns_help that will modify the
 function setup_fns_help(fns_help) {
   // console.log("got the fns_help in JS! " + JSON.stringify(fns_help));
+  console.log('got the fns_help in JS! ' + JSON.stringify(fns_help));
+  console.log('length of fns_help ' + Object.keys(fns_help));
+  console.log('first element of fns_help ' + JSON.stringify(fns_help[0]));
+
+
   // for each lineid, add a the fns_help words field
   // containing a list like:
   // [{word: "select", help_text: "<a id = 'mutate' class = 'fn_help'>mutate</a>"}, ...]
@@ -437,6 +443,12 @@ $(document).on("shiny:sessioninitialized", function(event) {
     console.log("trying to setup the callouts in JS")
     // set up the callouts
     setup_callouts(callouts);
+  });
+
+  Shiny.addCustomMessageHandler('fns_help', function(fns_help) {
+    console.log("trying to setup the fns_help in JS")
+    // set up the fns_help
+    setup_fns_help(fns_help);
   });
 
   Shiny.addCustomMessageHandler('prompts', function(summaries) {

--- a/inst/js/explorer.js
+++ b/inst/js/explorer.js
@@ -306,6 +306,11 @@ function setup_box_listeners() {
 Callouts
 */
 
+// TODO-add_function_help test out the token range info
+// we added on the code analysis side, if it goes well
+// and we can simply `markText` this will be much better
+// than usingg the regex way
+
 // helper function to callout parts of the code snippet
 function callout_code_text(callout, verb_doc) {
   // this marks the specific snippet within a verb document

--- a/inst/js/explorer.js
+++ b/inst/js/explorer.js
@@ -302,6 +302,10 @@ function setup_box_listeners() {
   Shiny.setInputValue("unravel-need_callouts", "Gimme the callouts! ", {priority: "event"});
 }
 
+/*
+Callouts
+*/
+
 // helper function to callout parts of the code snippet
 function callout_code_text(callout, verb_doc) {
   // this marks the specific snippet within a verb document
@@ -337,9 +341,6 @@ function callout_code_text(callout, verb_doc) {
   return callout_html_nodes;
 }
 
-/*
-Callouts
-*/
 
 function setup_callouts(callouts) {
   console.log("got the callouts in JS! " + JSON.stringify(callouts));
@@ -359,6 +360,31 @@ function setup_callouts(callouts) {
   Shiny.setInputValue("unravel-need_prompts", "we need the prompts now ", {priority: "event"});
 }
 
+/*
+Help text linking
+*/
+
+
+// TODO implement setup_fns_help that will modify the
+function setup_fns_help(fns_help) {
+  // console.log("got the fns_help in JS! " + JSON.stringify(fns_help));
+  // for each lineid, add a the fns_help words field
+  // containing a list like:
+  // [{word: "select", help_text: "<a id = 'mutate' class = 'fn_help'>mutate</a>"}, ...]
+  /*
+  fns_help.forEach(e => {
+
+  })
+  Shiny.setInputValue("unravel-need_prompts", "we need the prompts now ", {priority: "event"});
+  */
+}
+
+// helper function to callout parts of the code snippet
+function help_code_text(help_text, verb_doc) {
+
+}
+
+
 function send_toggle(message) {
   console.log("R received message from JS. " + message);
 }
@@ -372,6 +398,14 @@ $(document).ready(function() {
 // more information to UI from R. JS here will initialize prompts, toggles, and the summary box event listeners.
 $(document).on("shiny:sessioninitialized", function(event) {
   console.log("shiny initialized on explorer");
+
+  $('.fn_help').each(function(index, element) {
+  	// console.log(element.id);
+    element.addEventListener("click", function(event){
+    	console.log(event.target.id);
+    	Shiny.setInputValue("unravel-fn_help", event.target.id, {priority: "event"});
+  	})
+  })
 
   /*
   * Table interaction logging:

--- a/inst/js/explorer.js
+++ b/inst/js/explorer.js
@@ -306,43 +306,56 @@ function setup_box_listeners() {
 Callouts
 */
 
-// TODO-add_function_help test out the token range info
-// we added on the code analysis side, if it goes well
-// and we can simply `markText` this will be much better
-// than usingg the regex way
+// helper function to zip lists together like in Python
+// src: https://stackoverflow.com/a/10284006
+function zip(arrays) {
+    return arrays[0].map(function(_,i){
+        return arrays.map(function(array){return array[i]})
+    });
+}
 
 // helper function to callout parts of the code snippet
 function callout_code_text(callout, verb_doc) {
-  // this marks the specific snippet within a verb document
-  // such that we can refer to it later to enable or disable the span for callout highlights
-  let snippet = callout.word;
-  let lineNumber = 0;
-  // regex the boundary word
-  const re = new RegExp("(\\b" + snippet + "\\b)", 'g');
-  // for multi-lines, we need to split them into individual lines
-  // so that we can get the line number in addition to the match
-  let cur_lines = verb_doc.getValue().split("\n")
+  console.log('callout: ' + JSON.stringify(callout))
+  // get the content
+  const code =  verb_doc.getValue();
+  // setup a list containing all html nodes that will mark all instances of the
+  // callout word
   let callout_html_nodes = [];
-  for (const [index, line] of cur_lines.entries()) {
-    const matches = line.matchAll(re);
-    for (const m of matches) {
+  // this is to track what the first range's column start is (see NOTE below)
+  let beginning_start = 0;
+  for (const [index, ranges] of callout.location.entries()) {
+    beginning_start = (index == 0) ? ranges.col1[0] : 0;
+    // each callout could have multiple locations for one word
+    // for multiple lines, so we first zip up the range info
+    let location = zip([ranges.line1, ranges.line2, ranges.col1, ranges.col2]);
+    // go through each range of the locations and mark the text in the CodeMirror
+    // document using all of the range information for each instance of the word
+    for (const [index, range] of location.entries()) {
       let callout_html_node = document.createElement("span");
-      callout_html_node.innerHTML = snippet;
+      callout_html_node.innerHTML = callout.word;
       callout_html_node.id = callout.change;
-    	if (m !== undefined) {
-        let charNumber = m.index;
-        verb_doc.markText(
-          {line: index, ch: charNumber},
-          {line: index, ch: charNumber + snippet.length},
-          {replacedWith: callout_html_node}
-        )
-      } else {
-        // otherwise, set id to "" so that we don't call out any code text
-        callout_html_node.id = "";
-      }
+      const line1 = range[0] - 1;
+      const line2 = range[1] - 1;
+      // NOTE: the way codemirror works and the ranges we get from R via `getParseData()`
+      // sadly do not line up; in particular, the column start and end from R are going to
+      // be working off of a single-line string but the way CodeMirror marks up text conflicts
+      // with this because it assumes start is 0 for any new line. So, we are
+      // compensating for that discrepancy here by using the first line's range col1 so that
+      // we can appropriately subtract this first, and add 2 for the \t\t for both col1 and col2
+      // and one more for col2 bc JS excludes end range whereas R includes it.
+      let col_dec = (line1 > 0) ? beginning_start: 2
+      const col1 = range[2] - col_dec + 2;
+      const col2 = range[3] - col_dec + 3;
+      verb_doc.markText(
+        {line: line1, ch: col1},
+        {line: line2, ch: col2},
+        {replacedWith: callout_html_node}
+      );
       callout_html_nodes.push(callout_html_node);
     }
   }
+
   return callout_html_nodes;
 }
 
@@ -383,48 +396,52 @@ function setup_fns_help(fns_help) {
     let line_fns_help = e.fns_help;
     let line_fns_help_nodes = [];
     if (line_fns_help != null) {
-      line_fns_help_nodes = Object.keys(line_fns_help).forEach(fn_help => {
-        fns_help_code_text(fn_help, line_fns_help[fn_help], line_doc);
-      });
+      line_fns_help_nodes = line_fns_help.map(fn_help => fns_help_code_text(fn_help, line_doc));
     }
-    line.fns_help = line_fns_help_nodes;
+    line_fns_help_nodes = line_fns_help_nodes;
   })
 }
 
 // helper function to hyperlink parts of the code snippet that has a function call
-function fns_help_code_text(fn, fn_help, verb_doc) {
-  // this marks the specific snippet within a verb document
-  // such that we can refer to it later when user clicks on them to request Help docs
-  let lineNumber = 0;
-  // regex the boundary word
-  const re = new RegExp("(\\b" + fn + "\\b)", 'g');
-  // for multi-lines, we need to split them into individual lines
-  // so that we can get the line number in addition to the match
-  let cur_lines = verb_doc.getValue().split("\n")
+function fns_help_code_text(fn_help, verb_doc) {
+  console.log('fn_help: ' + JSON.stringify(fn_help))
+
+  let code = verb_doc.getValue();
   let fns_html_nodes = [];
-  for (const [index, line] of cur_lines.entries()) {
-    const matches = line.matchAll(re);
-    for (const m of matches) {
-      let fn_help_html_node = document.createElement("span");
-      fn_help_html_node.innerHTML = fn_help;
-      fn_help_html_node.id = fn;
-    	if (m !== undefined) {
-    	  fn_help_html_node.addEventListener("click", function(event){
+
+  // this is to track what the first range's column start is (see NOTE below)
+  let beginning_start = 0;
+  for (const [index, ranges] of fn_help.location.entries()) {
+    beginning_start = (index == 0) ? ranges.col1[0] : 0;
+    // each fn could have multiple locations for one word
+    // for multiple lines, so we first zip up the range info
+    let location = zip([ranges.line1, ranges.line2, ranges.col1, ranges.col2]);
+    // go through each range of the locations and mark the text in the CodeMirror
+    // document using all of the range information for each instance of the word
+    for (const [index, range] of location.entries()) {
+      let fn_html_node = document.createElement("span");
+      fn_html_node.innerHTML = fn_help.html;
+      fn_html_node.id = fn_help.word;
+      fn_html_node.addEventListener("click", function(event) {
         	Shiny.setInputValue("unravel-fn_help", event.target.id, {priority: "event"});
-      	})
-        let charNumber = m.index;
-        verb_doc.markText(
-          {line: index, ch: charNumber},
-          {line: index, ch: charNumber + fn.length},
-          {replacedWith: fn_help_html_node}
-        )
-      } else {
-        // otherwise, set id to "" so that we don't call out any code text
-        fn_help_html_node.id = "";
-      }
-      fns_html_nodes.push(fn_help_html_node);
+      });
+      const line1 = range[0] - 1;
+      const line2 = range[1] - 1;
+      // adjust ranges for CodeMirror (see the NOTE in `callout_code_text()`)
+      let col_dec = (line1 > 0) ? beginning_start: 2
+      const col1 = range[2] - col_dec + 2;
+      const col2 = range[3] - col_dec + 3;
+      // this marks the specific snippet within a verb document
+      // such that we can refer to it later when user clicks on them to request Help docs
+      verb_doc.markText(
+        {line: line1, ch: col1},
+        {line: line2, ch: col2},
+        {replacedWith: fn_html_node}
+      );
+      fns_html_nodes.push(fn_html_node);
     }
   }
+
   return fns_html_nodes;
 }
 


### PR DESCRIPTION
This PR addresses issue #30. In particular, the PR adds an ability to invoke the Help pane when a user clicks on a function in the code. Previously there was no way to reach for the function definition and its details, and this provides a way to leverage an already existing/familiar mechanism, the Help pane. This also unburdens us to have to somehow surface function docs up to the UI itself.

We take advantage of the fact that certain Shiny outputs like `plotOutput` allow calling `help()` and even though it's a hack currently, it invokes the Help pane. The forked tidylog will construct all of the HTML for each function call detected within the arguments of the tidyverse verb to make it look like it's a hyperlink text. However, the link will simply alert a JavaScript click listener that will in turn alert the Shiny server, which will invoke the `help()` programmatically.

TODOs:

- [x] add another cache for storing functions and their respective html to trigger Help on the IDE
- [x] test the plumbing 
- [x] finally, setup JS <=> R listeners for setting up help functions on the code text
- [x] make the respective changes on the forked `tidylog` for all of the main `dplyr`/`tidyr` functions
- [x]  some tests on snippets