### PR TITLE
Fixes issue #118 by not logging if options are not set

### DIFF
--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -317,7 +317,6 @@ unravelServer <- function(id, user_code = NULL) {
               rv$fns_help <- lapply(outputs, function(x) {
                 list(lineid = paste0("line", x$line), fns_help = x$fns_help)
               })
-              rv$cur_fns_help <- lapply(outputs, function(x) x$fns_help)
 
               rv$summaries <- lapply(outputs, function(x) {
                 if (!is.null(x$err)) {
@@ -545,6 +544,10 @@ unravelServer <- function(id, user_code = NULL) {
 
       output$fn_help_dummy <- renderPlot({
         if (!is.null(rv$cur_fns_help) && length(rv$cur_fns_help$pkg) > 0) {
+          # log event of referencing help page for a function
+          log_help(
+            paste0("Open help for ", paste0(rv$cur_fns_help$fn, ":", rv$cur_fns_help$pkg))
+          )
           help(rv$cur_fns_help$fn, rv$cur_fns_help$pkg)
         }
       })

--- a/R/utils.R
+++ b/R/utils.R
@@ -112,6 +112,10 @@ log_event <- function(message, context = "unravel") {
   log_unravel("EVENT", message, context)
 }
 
+log_help <- function(message, context = "unravel") {
+  log_unravel("HELP", message, context)
+}
+
 #' Log a code event
 #'
 #' A context either executed some code on the IDE or the Unravel app.
@@ -139,6 +143,10 @@ log_content_change <- function(content, path = "", context = "rstudio") {
 }
 
 log_unravel <- function(type, message, path = "", context = "unravel", storage = "sqlite") {
+  # first, check if all the required options are set, and if not quit early
+  unravel_log_options <- c("db.file", "unravel.logdir", "unravel.logfile", "unravel.logging")
+  are_options_set <- all(unravel_log_options %in% names(options()))
+  if (!are_options_set) return(invisible())
   # if logging is enabled, log
   if (getOption("unravel.logging")) {
     timestamp <- format(Sys.time())


### PR DESCRIPTION
This PR fixes the issue where Unravel crashed if options weren't set (it led to a 0 argument vector and broke an `if`). So, we fix that by checking if all the logging options are set. If so, there are no crashes, otherwise ignore and return early. 

We're also adding a log event when a user clicks a function to invoke its docs in the Help pane.