### PR TITLE
Add info about group numbers in table

### DIFF
--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -500,6 +500,7 @@ unravelServer <- function(id, user_code = NULL) {
           cols_with_types <- get_common_styles(final_data)
           all_cols <- get_column_css(final_data, rv$main_callout, cols_with_types)
           if (is_grouped_df(final_data)) {
+            ngroups_text <- glue::glue("# Groups: [{dplyr::n_groups(final_data)}]")
             return(
               do.call(
                 reactable::reactable,
@@ -509,7 +510,12 @@ unravelServer <- function(id, user_code = NULL) {
                     # rearrange the data such that group variables are at the beginning
                     data = dplyr::select(.data = final_data, group_vars(final_data), dplyr::everything()) %>% as.data.frame(),
                     columns = append(
-                      list(.rownames = colDef(style = list(textAlign = "left"), maxWidth = 80)),
+                      # add in the group number
+                      list(.rownames = colDef(
+                        name = glue::glue("<div class = 'groups'>{ngroups_text}</div>"),
+                        html = TRUE,
+                        maxWidth = 100)
+                      ),
                       all_cols
                     )
                   )

--- a/inst/css/style.css
+++ b/inst/css/style.css
@@ -62,6 +62,16 @@ h2 {
   border-radius: 0.5rem;
 }
 
+.groups {
+  width: auto;
+  height: 2em;
+  font-size: 0.8em;
+  text-align: left;
+  padding: 2px;
+  background: lightblue;
+  border-radius: 0.5rem;
+}
+
 .internal-square-key:hover{
   cursor:pointer
 }


### PR DESCRIPTION
This PR addresses issue #117 by adding the number of groups on the rowname column header:

![Screen Shot 2022-03-17 at 4 36 21 PM](https://user-images.githubusercontent.com/9612286/158890864-97f395e5-c29a-43e6-937d-81083985a5a5.png)

This will work for arbitrary number of groups (for e.g. 2 groups):

![Screen Shot 2022-03-17 at 4 37 18 PM](https://user-images.githubusercontent.com/9612286/158890988-93abaf26-fb0e-439f-90d4-28f9f1170577.png)

 