### PR TITLE
Fix function and variable code highlights

### DIFF
--- a/R/code_analysis.R
+++ b/R/code_analysis.R
@@ -152,7 +152,7 @@ gather_callouts <- function(callouts, deparsed) {
   return(list(callouts))
 }
 
-# helper function to add some range info for the function help words
+# helper function to add the function name and html info for the function help words
 gather_fns_help <- function(fns_help, deparsed) {
   # store some info about the range so JS knows which
   code <- trimws(deparsed)
@@ -161,6 +161,9 @@ gather_fns_help <- function(fns_help, deparsed) {
   # grab the col1, col2, and text
   filtered_tree <- parse_tree[parse_tree$token == 'SYMBOL_FUNCTION_CALL', ]
   filtered_fns_help <- filtered_tree[c('text', 'line1', 'line2', 'col1', 'col2')]
+  # if there are no function help words gathered from tidylog BUT there are
+  # function calls from the parse tree info, then let's construct a function
+  # list so we can use it to hyperlink functions on JS side
   if (length(fns_help) == 0 && nrow(filtered_fns_help) > 0) {
     return(
       list(
@@ -168,28 +171,8 @@ gather_fns_help <- function(fns_help, deparsed) {
           filtered_fns_help$text,
           function(fn_name) {
             fn <- list(word = fn_name, html = glue::glue("<a id='{fn_name}' class='fn_help'>{fn_name}</a>"))
-            token_info <- filtered_fns_help[filtered_fns_help$text == fn_name, ]
-            fn[['location']] <- list(token_info)
             fn
           }
-        )
-      )
-    )
-  }
-  if (nrow(filtered_fns_help) > 0) {
-    # return a list of callouts with the range information baked in for JS to mark
-    return(
-      list(
-        modifyList(
-          lapply(
-            fns_help,
-            function(fn) {
-              token_info <- filtered_fns_help[filtered_fns_help$text == fn$word, ]
-              fn[['location']] <- list(token_info)
-              fn
-            }
-          ),
-          list(fns_help)
         )
       )
     )


### PR DESCRIPTION
This PR fixes issue #126, where the function hyperlink callouts were breaking things. It also turns out that the callouts would also break on sufficiently long lines that break into multiple lines for a given Unravel line. So, the main change done here to combat this and make implementation easier and less brittle is to actually use a smarter regex approach:

- for variable callouts, do a boundary regex but excluding open parens to exclude function calls that may have the same name as variable `(\bcallout\b)(?!\()`
- for function callouts, do a boundary regex `(\bfunction\b)`

